### PR TITLE
squid:S1197 - Array designators "[]" should be on the type, not the variable

### DIFF
--- a/src/main/java/eus/ixa/ixa/pipe/nerc/formats/CoNLL02Format.java
+++ b/src/main/java/eus/ixa/ixa/pipe/nerc/formats/CoNLL02Format.java
@@ -103,7 +103,7 @@ public class CoNLL02Format implements ObjectStream<NameSample> {
           throw new IOException("Empty line after -DOCSTART- not empty: '" + emptyLine +"'!");
         continue;
       }
-      String fields[] = line.split("\t");
+      String[] fields = line.split("\t");
       if (fields.length == 2) {
         tokens.add(fields[0]);
         neTypes.add(fields[1]);

--- a/src/main/java/eus/ixa/ixa/pipe/nerc/formats/CoNLL03Format.java
+++ b/src/main/java/eus/ixa/ixa/pipe/nerc/formats/CoNLL03Format.java
@@ -102,7 +102,7 @@ public class CoNLL03Format implements ObjectStream<NameSample>{
           throw new IOException("Empty line after -DOCSTART- not empty: '" + emptyLine +"'!");
         continue;
       }
-      String fields[] = line.split("\t");
+      String[] fields = line.split("\t");
       if (fields.length == 2) {
         tokens.add(fields[0]);
         neTypes.add(fields[1]);

--- a/src/main/java/eus/ixa/ixa/pipe/nerc/lexer/NumericLexer.java
+++ b/src/main/java/eus/ixa/ixa/pipe/nerc/lexer/NumericLexer.java
@@ -39,7 +39,7 @@ class NumericLexer {
    *                  at the beginning of a line
    * l is of the form l = 2*k, k a non negative integer
    */
-  private static final int ZZ_LEXSTATE[] = { 
+  private static final int[] ZZ_LEXSTATE = {
      0, 0
   };
 
@@ -1272,7 +1272,7 @@ class NumericLexer {
   private static final int ZZ_PUSHBACK_2BIG = 2;
 
   /* error messages for the codes above */
-  private static final String ZZ_ERROR_MSG[] = {
+  private static final String[] ZZ_ERROR_MSG = {
     "Unkown internal scanner error",
     "Error: could not match input",
     "Error: pushback value was too large"
@@ -1326,7 +1326,7 @@ class NumericLexer {
 
   /** this buffer contains the current text to be matched and is
       the source of the yytext() string */
-  private char zzBuffer[] = new char[ZZ_BUFFERSIZE];
+  private char[] zzBuffer = new char[ZZ_BUFFERSIZE];
 
   /** the textposition at the last accepting state */
   private int zzMarkedPos;
@@ -1464,7 +1464,7 @@ class NumericLexer {
     /* is the buffer big enough? */
     if (zzCurrentPos >= zzBuffer.length) {
       /* if not: blow it up */
-      char newBuffer[] = new char[zzCurrentPos*2];
+      char[] newBuffer = new char[zzCurrentPos*2];
       System.arraycopy(zzBuffer, 0, newBuffer, 0, zzBuffer.length);
       zzBuffer = newBuffer;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1197 - Array designators "[]" should be on the type, not the variable.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1197
Please let me know if you have any questions.
George Kankava