### PR TITLE
Multiple code improvements - squid:CommentedOutCodeLine, squid:S1854, squid:S2131, squid:S2293

### DIFF
--- a/src/main/java/eus/ixa/ixa/pipe/nerc/NumericNameFinder.java
+++ b/src/main/java/eus/ixa/ixa/pipe/nerc/NumericNameFinder.java
@@ -45,7 +45,6 @@ public class NumericNameFinder implements NameFinder {
     List<Span> neSpans = new ArrayList<Span>();
     List<Name> flexNameList = numericLexer.getNumericNames();
     for (Name name : flexNameList) {
-      //System.err.println("numeric name: " + name.value());
       List<Integer> neIds = StringUtils.exactTokenFinderIgnoreCase(name.value(), tokens);
       for (int i = 0; i < neIds.size(); i += 2) {
         Span neSpan = new Span(neIds.get(i), neIds.get(i+1), name.getType());

--- a/src/main/java/eus/ixa/ixa/pipe/nerc/eval/CrossValidator.java
+++ b/src/main/java/eus/ixa/ixa/pipe/nerc/eval/CrossValidator.java
@@ -83,7 +83,7 @@ public class CrossValidator {
   /**
    * The evaluation listeners.
    */
-  private List<EvaluationMonitor<NameSample>> listeners = new LinkedList<EvaluationMonitor<NameSample>>();
+  private List<EvaluationMonitor<NameSample>> listeners = new LinkedList<>();
   TokenNameFinderDetailedFMeasureListener detailedFListener;
 
   

--- a/src/main/java/eus/ixa/ixa/pipe/nerc/eval/Evaluate.java
+++ b/src/main/java/eus/ixa/ixa/pipe/nerc/eval/Evaluate.java
@@ -56,7 +56,7 @@ public class Evaluate {
    * language codes, the values the models.
    */
   private static ConcurrentHashMap<String, TokenNameFinderModel> nercModels =
-      new ConcurrentHashMap<String, TokenNameFinderModel>();
+      new ConcurrentHashMap<>();
  
   /**
    * Construct an evaluator. It takes from the properties a model,
@@ -100,7 +100,7 @@ public class Evaluate {
    * @throws IOException if test corpus not loaded
    */
   public final void detailEvaluate() throws IOException {
-    List<EvaluationMonitor<NameSample>> listeners = new LinkedList<EvaluationMonitor<NameSample>>();
+    List<EvaluationMonitor<NameSample>> listeners = new LinkedList<>();
     TokenNameFinderDetailedFMeasureListener detailedFListener = new TokenNameFinderDetailedFMeasureListener();
     listeners.add(detailedFListener);
     TokenNameFinderEvaluator evaluator = new TokenNameFinderEvaluator(nameFinder,
@@ -113,7 +113,7 @@ public class Evaluate {
    * @throws IOException if test corpus not loaded
    */
   public final void evalError() throws IOException {
-    List<EvaluationMonitor<NameSample>> listeners = new LinkedList<EvaluationMonitor<NameSample>>();
+    List<EvaluationMonitor<NameSample>> listeners = new LinkedList<>();
     listeners.add(new NameEvaluationErrorListener());
     TokenNameFinderEvaluator evaluator = new TokenNameFinderEvaluator(nameFinder,
         listeners.toArray(new TokenNameFinderEvaluationMonitor[listeners.size()]));

--- a/src/main/java/eus/ixa/ixa/pipe/nerc/features/WordShapeSuperSenseFeatureGenerator.java
+++ b/src/main/java/eus/ixa/ixa/pipe/nerc/features/WordShapeSuperSenseFeatureGenerator.java
@@ -55,7 +55,7 @@ public class WordShapeSuperSenseFeatureGenerator extends CustomFeatureGenerator 
 
     char currentCharacter;
     int prevCharType = -1;
-    char charType = '~';
+    char charType;
     boolean addedStar = false;
     for (int i = 0; i < token.length(); i++) {
 
@@ -77,7 +77,7 @@ public class WordShapeSuperSenseFeatureGenerator extends CustomFeatureGenerator 
         }
       } else {
         addedStar = false;
-        normalizedToken += charType;
+        normalizedToken += Character.toString(charType);
       }
       prevCharType = charType;
     }

--- a/src/main/java/eus/ixa/ixa/pipe/nerc/formats/CoNLL02Format.java
+++ b/src/main/java/eus/ixa/ixa/pipe/nerc/formats/CoNLL02Format.java
@@ -127,8 +127,6 @@ public class CoNLL02Format implements ObjectStream<NameSample> {
         if (neTag.startsWith("B-")) {
           if (beginIndex != -1) {
             names.add(extract(beginIndex, endIndex, neTypes.get(beginIndex)));
-            beginIndex = -1;
-            endIndex = -1;
           }
           beginIndex = i;
           endIndex = i + 1;

--- a/src/main/java/eus/ixa/ixa/pipe/nerc/lexer/NumericLexer.java
+++ b/src/main/java/eus/ixa/ixa/pipe/nerc/lexer/NumericLexer.java
@@ -1716,24 +1716,20 @@ class NumericLexer {
               break;
             case FIRST_DELETE:
               if ( ! this.seenUntokenizableCharacter) {
-                //LOGGER.warning(msg);
                 this.seenUntokenizableCharacter = true;
               }
               break;
             case ALL_DELETE:
-              //LOGGER.warning(msg);
               this.seenUntokenizableCharacter = true;
               break;
             case NONE_KEEP:
               return makeName();
             case FIRST_KEEP:
               if ( ! this.seenUntokenizableCharacter) {
-                //LOGGER.warning(msg);
                 this.seenUntokenizableCharacter = true;
               }
               return makeName();
             case ALL_KEEP:
-              //LOGGER.warning(msg);
               this.seenUntokenizableCharacter = true;
               return makeName();
           }

--- a/src/main/java/eus/ixa/ixa/pipe/nerc/lexer/NumericNameLexer.java
+++ b/src/main/java/eus/ixa/ixa/pipe/nerc/lexer/NumericNameLexer.java
@@ -63,7 +63,7 @@ public class NumericNameLexer {
    * @return A list of all tokens remaining in the underlying Reader
    */
   public List<Name> getNumericNames() {
-    List<Name> result = new ArrayList<Name>();
+    List<Name> result = new ArrayList<>();
     while (hasNextToken()) {
       result.add(getNextToken());
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:S1854 - Dead stores should be removed.
squid:S2131 - Primitives should not be boxed just for "String" conversion.
squid:S2293 - The diamond operator ("<>") should be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S2131
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
George Kankava