### PR TITLE
squid:S2293 - The diamond operator ("<>") should be used

### DIFF
--- a/src/main/java/eus/ixa/ixa/pipe/nerc/dict/BrownCluster.java
+++ b/src/main/java/eus/ixa/ixa/pipe/nerc/dict/BrownCluster.java
@@ -62,7 +62,7 @@ public class BrownCluster implements SerializableArtifact {
     }
   }
   
-  private Map<String, String> tokenToClusterMap = new HashMap<String, String>();
+  private Map<String, String> tokenToClusterMap = new HashMap<>();
 
   /**
    * Generates the token to cluster map from Brown cluster input file.

--- a/src/main/java/eus/ixa/ixa/pipe/nerc/dict/ClarkCluster.java
+++ b/src/main/java/eus/ixa/ixa/pipe/nerc/dict/ClarkCluster.java
@@ -67,7 +67,7 @@ public class ClarkCluster implements SerializableArtifact {
     }
   }
   
-  private Map<String, String> tokenToClusterMap = new HashMap<String, String>();
+  private Map<String, String> tokenToClusterMap = new HashMap<>();
 
   public ClarkCluster(InputStream in) throws IOException {
 

--- a/src/main/java/eus/ixa/ixa/pipe/nerc/dict/Dictionaries.java
+++ b/src/main/java/eus/ixa/ixa/pipe/nerc/dict/Dictionaries.java
@@ -113,9 +113,9 @@ public class Dictionaries {
    */
   private void loadDictionaries(final String inputDir) throws IOException {
     List<File> fileList = StringUtils.getFilesInDir(new File(inputDir));
-    dictNames = new ArrayList<String>(fileList.size());
-    dictionaries = new ArrayList<Map<String, String>>(fileList.size());
-    dictionariesIgnoreCase = new ArrayList<Map<String, String>>(fileList.size());
+    dictNames = new ArrayList<>(fileList.size());
+    dictionaries = new ArrayList<>(fileList.size());
+    dictionariesIgnoreCase = new ArrayList<>(fileList.size());
     System.err.println("\tloading dictionaries in " + inputDir + " directory");
     for (int i = 0; i < fileList.size(); ++i) {
       if (DEBUG) {

--- a/src/main/java/eus/ixa/ixa/pipe/nerc/dict/Dictionary.java
+++ b/src/main/java/eus/ixa/ixa/pipe/nerc/dict/Dictionary.java
@@ -62,7 +62,7 @@ public class Dictionary implements SerializableArtifact {
     }
   }
   
-  private Map<String, String> dictionary = new HashMap<String, String>();
+  private Map<String, String> dictionary = new HashMap<>();
 
   public Dictionary(InputStream in) throws IOException {
 
@@ -110,7 +110,7 @@ public class Dictionary implements SerializableArtifact {
    */
   public List<String> getBioDictionaryMatch(String[] tokens) {
 
-    List<String> entitiesList = new ArrayList<String>();
+    List<String> entitiesList = new ArrayList<>();
 
     String prefix = "-" + BioCodec.START;
     String gazEntry = null;
@@ -155,7 +155,7 @@ public class Dictionary implements SerializableArtifact {
    */
   public List<String> getBilouDictionaryMatch(String[] tokens) {
 
-    List<String> entitiesList = new ArrayList<String>();
+    List<String> entitiesList = new ArrayList<>();
 
     String prefix = "-" + BilouCodec.START;
     String gazClass = null;

--- a/src/main/java/eus/ixa/ixa/pipe/nerc/dict/LemmaResource.java
+++ b/src/main/java/eus/ixa/ixa/pipe/nerc/dict/LemmaResource.java
@@ -68,7 +68,7 @@ public class LemmaResource implements SerializableArtifact {
    * @throws IOException the io exception
    */
   public LemmaResource(InputStream in) throws IOException {
-    dictMap = new HashMap<List<String>, String>();
+    dictMap = new HashMap<>();
     BufferedReader breader = new BufferedReader(new InputStreamReader(
         in));
     String line;
@@ -114,7 +114,7 @@ public class LemmaResource implements SerializableArtifact {
    * @return the lemmas for the sentence
    */
   public List<String> lookUpLemmaArray(String[] tokens, String[] postags) {
-    List<String> lemmas = new ArrayList<String>();
+    List<String> lemmas = new ArrayList<>();
     for (int i = 0; i < tokens.length; i++) {
       String lemma = lookUpLemma(tokens[i], postags[i]);
       lemmas.add(lemma);
@@ -134,7 +134,7 @@ public class LemmaResource implements SerializableArtifact {
   private List<String> getDictKeys(final String word,
       final String postag) {
     String constantTag = "NNP";
-    List<String> keys = new ArrayList<String>();
+    List<String> keys = new ArrayList<>();
     if (postag.startsWith(String.valueOf(constantTag))) {
       keys.addAll(Arrays.asList(word, postag));
     } else {

--- a/src/main/java/eus/ixa/ixa/pipe/nerc/dict/MFSResource.java
+++ b/src/main/java/eus/ixa/ixa/pipe/nerc/dict/MFSResource.java
@@ -101,7 +101,7 @@ public class MFSResource implements SerializableArtifact {
    */
   public List<String> getFirstSenseBio(List<String> lemmas, String[] posTags) {
 
-    List<String> mostFrequentSenseList = new ArrayList<String>();
+    List<String> mostFrequentSenseList = new ArrayList<>();
 
     String prefix = "-" + BioCodec.START;
     String mostFrequentSense = null;
@@ -162,7 +162,7 @@ public class MFSResource implements SerializableArtifact {
    */
   public List<String> getFirstSenseBilou(List<String> lemmas, String[] posTags) {
 
-    List<String> mostFrequentSenseList = new ArrayList<String>();
+    List<String> mostFrequentSenseList = new ArrayList<>();
 
     String prefix = "-" + BioCodec.START;
     String mostFrequentSense = null;

--- a/src/main/java/eus/ixa/ixa/pipe/nerc/dict/Word2VecCluster.java
+++ b/src/main/java/eus/ixa/ixa/pipe/nerc/dict/Word2VecCluster.java
@@ -64,7 +64,7 @@ public class Word2VecCluster implements SerializableArtifact {
     }
   }
   
-  private Map<String, String> tokenToClusterMap = new HashMap<String, String>();
+  private Map<String, String> tokenToClusterMap = new HashMap<>();
   
   public Word2VecCluster(InputStream in) throws IOException {
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2293 - The diamond operator ("<>") should be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
George Kankava