### PR TITLE
Fixing squid: S1118 Utility classes should not have public constructors

### DIFF
--- a/src/main/java/eus/ixa/ixa/pipe/nerc/SpanUtils.java
+++ b/src/main/java/eus/ixa/ixa/pipe/nerc/SpanUtils.java
@@ -20,7 +20,9 @@ import java.util.List;
 
 import opennlp.tools.util.Span;
 
-public class SpanUtils {
+public final class SpanUtils {
+	
+  private SpanUtils() {}	
   
   /**
    * Concatenates two span lists adding the spans of the second parameter to the

--- a/src/main/java/eus/ixa/ixa/pipe/nerc/features/BrownTokenClasses.java
+++ b/src/main/java/eus/ixa/ixa/pipe/nerc/features/BrownTokenClasses.java
@@ -26,7 +26,9 @@ import eus.ixa.ixa.pipe.nerc.dict.BrownCluster;
  * @author ragerri 2014-10-14
  *
  */
-public class BrownTokenClasses {
+public final class BrownTokenClasses {
+	
+  private BrownTokenClasses() {}	
   
   public static final int[] pathLengths = { 4, 6, 10, 20 };
   


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1118 - “Utility classes should not have public constructors ”. 
This PR will remove 60min of TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1118
 Please let me know if you have any questions.
 Fevzi Ozgul
